### PR TITLE
fix value field duplicated as custom parameter

### DIFF
--- a/inventree_kicad/serializers.py
+++ b/inventree_kicad/serializers.py
@@ -203,6 +203,7 @@ class KicadDetailedPartSerializer(serializers.ModelSerializer):
             self.plugin.get_setting('KICAD_EXCLUDE_FROM_BOM_PARAMETER', None),
             self.plugin.get_setting('KICAD_EXCLUDE_FROM_BOARD_PARAMETER', None),
             self.plugin.get_setting('KICAD_EXCLUDE_FROM_SIM_PARAMETER', None),
+            self.plugin.get_setting('KICAD_VALUE_PARAMETER', None),
         ]
 
         excluded_field_names = [


### PR DESCRIPTION
This excludes the `KICAD_VALUE_PARAMETER` field from the list of custom parameters.

I was wondering why my value field was appearing as a custom parameter, i guess this is unintentional and was just forgotten here?