### PR TITLE
KiCad backup symbol support

### DIFF
--- a/inventree_kicad/KiCadLibraryPlugin.py
+++ b/inventree_kicad/KiCadLibraryPlugin.py
@@ -73,6 +73,13 @@ class KiCadLibraryPlugin(UrlsMixin, AppMixin, SettingsMixin, SettingsContentMixi
             'validator': bool,
             'default': False,
         },
+        'IMPORT_INVENTREE_ID_FALLBACK': {
+            'name': _('Also Match Against Part Name'),
+            'description': _(
+                'When activated, the import tool will use the part name as fallback if the ID does not return an existing part.'),
+            'validator': bool,
+            'default': False,
+        },
         'KICAD_SYMBOL_PARAMETER': {
             'name': _('Symbol Parameter'),
             'description': _('The part parameter to use for the symbol name.'),
@@ -114,12 +121,10 @@ class KiCadLibraryPlugin(UrlsMixin, AppMixin, SettingsMixin, SettingsContentMixi
             'description': _('This identifier specifies what key the import tool looks for to get the part ID'),
             'default': "InvenTree"
         },
-        'IMPORT_INVENTREE_ID_FALLBACK': {
-            'name': _('Also Match Against Part Name'),
-            'description': _(
-                'When activated, the import tool will use the part name as fallback if the ID does not return an existing part.'),
-            'validator': bool,
-            'default': False,
+        'DEFAULT_FOR_MISSING_SYMBOL': {
+            'name': _('Backup KiCad Symbol'),
+            'description': _('This backup symbol will be used if none has been defined'),
+            'default': ""
         },
     }
 

--- a/inventree_kicad/serializers.py
+++ b/inventree_kicad/serializers.py
@@ -140,8 +140,8 @@ class KicadDetailedPartSerializer(serializers.ModelSerializer):
         # colon. Replace the other colons with underscores.
         cnt = symbol.count(':')
         if cnt != 1 and len(symbol) != 0:
-
             spilt_str = symbol.split(':')
+            tmp_str = ""
 
             for iter, s in enumerate(spilt_str):
                 tmp_str += s

--- a/inventree_kicad/serializers.py
+++ b/inventree_kicad/serializers.py
@@ -132,13 +132,16 @@ class KicadDetailedPartSerializer(serializers.ModelSerializer):
 
         symbol = self.get_parameter_value(part, template_id, backup_value=symbol)
 
+        if not symbol:
+            symbol = template_id = self.plugin.get_setting('DEFAULT_FOR_MISSING_SYMBOL', "")
+
         # KiCad does not like colons in their symbol names.
         # Check if there is more than one colon present, if so rebuild string and honour only the first
         # colon. Replace the other colons with underscores.
         cnt = symbol.count(':')
-        if cnt != 1:
+        if cnt != 1 and len(symbol) != 0:
+
             spilt_str = symbol.split(':')
-            tmp_str = ""
 
             for iter, s in enumerate(spilt_str):
                 tmp_str += s


### PR DESCRIPTION
Added a setting to store a backup symbol which is used if there is no symbol defined. 
If not set, KiCad will not show any symbol when placed which looks a bit awkward.