### PR TITLE
Query speed fix

### DIFF
--- a/inventree_kicad/KiCadLibraryPlugin.py
+++ b/inventree_kicad/KiCadLibraryPlugin.py
@@ -67,7 +67,7 @@ class KiCadLibraryPlugin(UrlsMixin, AppMixin, SettingsMixin, SettingsContentMixi
         'KICAD_ENABLE_STOCK_COUNT_FORMAT': {
             'name': _('Display Format for Stock Count'),
             'description': _('This will be displayed after the part\'s description in KiCad (right column). Note: {1} contains the Stock information, {0} the description of the part.'),
-            'default': "[Stock: {1}] >> {0}"
+            'default': "[Stock: {1}] {0}"
         },
         'DEFAULT_FOR_MISSING_SYMBOL': {
             'name': _('Backup KiCad Symbol'),

--- a/inventree_kicad/serializers.py
+++ b/inventree_kicad/serializers.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
@@ -11,6 +13,8 @@ from InvenTree.helpers import str2bool, decimal2string
 
 from .models import SelectedCategory, FootprintParameterMapping
 
+
+logger = logging.getLogger('inventree')
 
 class KicadDetailedPartSerializer(serializers.ModelSerializer):
     """Custom model serializer for a single KiCad part instance"""
@@ -435,8 +439,8 @@ class KicadPreviewPartSerializer(serializers.ModelSerializer):
         if self.enable_stock_count:
             try:
                 description = self.stock_count_format.format(part.description, decimal2string(stock_count))
-            except Exception:
-                pass
+            except Exception as e:
+                logger.exception("Failed to format stock count: %s", e)
 
         return description
 

--- a/inventree_kicad/serializers.py
+++ b/inventree_kicad/serializers.py
@@ -419,10 +419,21 @@ class KicadPreviewPartSerializer(serializers.ModelSerializer):
         if they enable it.
         """
 
-        if str2bool(self.plugin.get_setting('KICAD_ENABLE_STOCK_COUNT', False)):
-            return self.plugin.get_setting("KICAD_ENABLE_STOCK_COUNT_FORMAT", "[Stock: {1}] >> {0}").format(part.description, decimal2string(part.get_stock_count()))
+        if not hasattr(self, 'enable_stock_count'):
+            self.enable_stock_count = str2bool(self.plugin.get_setting('KICAD_ENABLE_STOCK_COUNT', False))
+        
+        if not hasattr(self, 'stock_count_format'):
+            self.stock_count_format = self.plugin.get_setting("KICAD_ENABLE_STOCK_COUNT_FORMAT", False)
 
-        return part.name
+        description = part.description
+
+        if self.enable_stock_count:
+            try:
+                description = self.stock_count_format.format(part.description, decimal2string(part.get_stock_count()))
+            except Exception:
+                pass
+
+        return description
 
 
 class KicadCategorySerializer(serializers.ModelSerializer):

--- a/inventree_kicad/serializers.py
+++ b/inventree_kicad/serializers.py
@@ -16,6 +16,7 @@ from .models import SelectedCategory, FootprintParameterMapping
 
 logger = logging.getLogger('inventree')
 
+
 class KicadDetailedPartSerializer(serializers.ModelSerializer):
     """Custom model serializer for a single KiCad part instance"""
 

--- a/inventree_kicad/viewsets.py
+++ b/inventree_kicad/viewsets.py
@@ -4,6 +4,9 @@ from InvenTree.helpers import str2bool
 from part.models import PartCategory, Part
 
 
+from inventree_kicad import serializers
+
+
 class Index(views.APIView):
     """Index view which provides a list of available endpoints"""
 
@@ -29,9 +32,7 @@ class Index(views.APIView):
 class CategoryList(generics.ListAPIView):
     """List of available KiCad categories"""
 
-    from .serializers import KicadCategorySerializer
-
-    serializer_class = KicadCategorySerializer
+    serializer_class = serializers.KicadCategorySerializer
 
     def get_queryset(self):
         """Return only PartCategory objects which are mapped to a SelectedCategory"""
@@ -46,9 +47,7 @@ class CategoryList(generics.ListAPIView):
 class PartsPreviewList(generics.ListAPIView):
     """Preview list for all parts in a given category"""
 
-    from .serializers import KicadPreviewPartSerializer
-
-    serializer_class = KicadPreviewPartSerializer
+    serializer_class = serializers.KicadPreviewPartSerializer
 
     def get_serializer(self, *args, **kwargs):
         """Add the parent plugin instance to the serializer contenxt"""
@@ -63,7 +62,6 @@ class PartsPreviewList(generics.ListAPIView):
         We check if the plugin setting KICAD_ENABLE_SUBCATEGORY is enabled,
         to determine if sub-category parts should be returned also
         """
-        from .serializers import KicadPreviewPartSerializer
 
         category_id = self.kwargs.get('id', None)
 
@@ -84,7 +82,7 @@ class PartsPreviewList(generics.ListAPIView):
             else:
                 queryset = queryset.filter(category=category)
 
-        queryset = KicadPreviewPartSerializer.annotate_queryset(queryset)
+        queryset = serializers.KicadPreviewPartSerializer.annotate_queryset(queryset)
 
         return queryset
 
@@ -96,9 +94,7 @@ class PartDetail(generics.RetrieveAPIView):
     The custom plugin serializer formats the data into a KiCad compatible format.
     """
 
-    from .serializers import KicadDetailedPartSerializer
-
-    serializer_class = KicadDetailedPartSerializer
+    serializer_class = serializers.KicadDetailedPartSerializer
     queryset = Part.objects.all()
 
     def get_queryset(self):

--- a/inventree_kicad/viewsets.py
+++ b/inventree_kicad/viewsets.py
@@ -88,6 +88,7 @@ class PartsPreviewList(generics.ListAPIView):
 
         return queryset
 
+
 class PartDetail(generics.RetrieveAPIView):
     """Detailed information endpoint for a single part instance.
     


### PR DESCRIPTION
Significantly improves the lookup speed of the "preview" list, by:

1. Caching settings values into the serializer instance
2. Annotating the database query appropriately

For a dataset with 400 parts, this reduces:

a. Request time from ~2s down to ~300ms
b. Number of DB queries from ~2500 down to ~25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Modified the default display format for stock count information in KiCad, removing the `>>` symbol for a cleaner presentation.
	- Enhanced the handling of stock count display in descriptions for parts, with new logic that adapts to user settings.
- **Refactor**
	- Optimized the handling of part categories and sub-categories in the KiCad plugin for more efficient data filtering and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->