### PR TITLE
Add REST API to manage selected KiCad categories

### DIFF
--- a/inventree_kicad/KiCadLibraryPlugin.py
+++ b/inventree_kicad/KiCadLibraryPlugin.py
@@ -13,6 +13,8 @@ from django.template.loader import render_to_string
 from django.urls import include, re_path
 from django.utils.translation import gettext_lazy as _
 
+from rest_framework import routers
+
 from InvenTree.helpers import str2bool
 from common.notifications import logger
 from part.models import Part, PartParameterTemplate, PartParameter
@@ -161,6 +163,13 @@ class KiCadLibraryPlugin(UrlsMixin, AppMixin, SettingsMixin, SettingsContentMixi
 
         from . import viewsets
 
+        api_category_router = routers.DefaultRouter()
+        api_category_router.register(r'category', viewsets.CategoryApi, basename='selectedcategory')
+
+        api_urls = [
+            re_path('', include(api_category_router.urls)),
+        ]
+
         return [
             re_path(r'v1/', include([
                 re_path(r'parts/', include([
@@ -183,6 +192,8 @@ class KiCadLibraryPlugin(UrlsMixin, AppMixin, SettingsMixin, SettingsContentMixi
 
             re_path(r'upload(?:\.(?P<format>json))?$', self.import_meta_data, name='meta_data_upload'),
             re_path(r'progress_bar_status', self.get_import_progress, name='get_import_progress'),
+
+            re_path(r'api/', include(api_urls), name='api'),
 
             # Anything else, redirect to our top-level v1 page
             re_path('^.*$', viewsets.Index.as_view(), name='kicad-index'),

--- a/inventree_kicad/serializers.py
+++ b/inventree_kicad/serializers.py
@@ -487,3 +487,28 @@ class KicadCategorySerializer(serializers.ModelSerializer):
 
     def get_name(self, category):
         return category.pathstring
+
+class KicadDetailedCategorySerializer(serializers.ModelSerializer):
+    """Custom model serializer for a single KiCad category instance"""
+
+    class Meta:
+        """Metaclass defining serializer fields"""
+        model = SelectedCategory
+        fields = [
+            'pk',
+            'category',
+            'default_symbol',
+            'default_footprint',
+            'default_reference',
+            'default_value_parameter_template',
+            'footprint_parameter_template',
+        ]
+
+    def __init__(self, *args, **kwargs):
+        super(KicadDetailedCategorySerializer, self).__init__(*args, **kwargs)
+        request = self.context.get('request')
+        if request and request.method in ["POST", "PUT", "PATCH"]:
+            self.Meta.depth = 0
+        else:
+            self.Meta.depth = 1
+

--- a/inventree_kicad/serializers.py
+++ b/inventree_kicad/serializers.py
@@ -488,6 +488,7 @@ class KicadCategorySerializer(serializers.ModelSerializer):
     def get_name(self, category):
         return category.pathstring
 
+
 class KicadDetailedCategorySerializer(serializers.ModelSerializer):
     """Custom model serializer for a single KiCad category instance"""
 
@@ -511,4 +512,3 @@ class KicadDetailedCategorySerializer(serializers.ModelSerializer):
             self.Meta.depth = 0
         else:
             self.Meta.depth = 1
-

--- a/inventree_kicad/viewsets.py
+++ b/inventree_kicad/viewsets.py
@@ -30,6 +30,7 @@ class Index(views.APIView):
             }
         )
 
+
 class CategoryApi(rest_viewsets.ViewSet):
     from .models import SelectedCategory
     queryset = SelectedCategory.objects.all()
@@ -38,7 +39,6 @@ class CategoryApi(rest_viewsets.ViewSet):
     def get_serializer(self, *args, **kwargs):
         """Add the parent plugin instance to the serializer contenxt"""
 
-        #kwargs['plugin'] = self.kwargs['plugin']
         kwargs['context'] = {'request': self.request}
 
         return self.serializer_class(*args, **kwargs)
@@ -110,7 +110,7 @@ class CategoryApi(rest_viewsets.ViewSet):
         # Allow passing the parameter name instead of the id
         for parameter in ['default_value_parameter_template', 'footprint_parameter_template']:
             key = 'name' if isinstance(request.data.get(parameter), str) else 'pk'
-            validated_data[parameter] = PartParameterTemplate.objects.filter(**{key:request.data.get(parameter)}).first()
+            validated_data[parameter] = PartParameterTemplate.objects.filter(**{key: request.data.get(parameter)}).first()
 
         serializer = serializers.KicadDetailedCategorySerializer()
         created_category = serializer.create(validated_data)
@@ -126,6 +126,7 @@ class CategoryApi(rest_viewsets.ViewSet):
         category.delete()
 
         return response.Response(status=204)
+
 
 class CategoryList(generics.ListAPIView):
     """List of available KiCad categories"""

--- a/inventree_kicad/viewsets.py
+++ b/inventree_kicad/viewsets.py
@@ -49,10 +49,10 @@ class CategoryApi(rest_viewsets.ViewSet):
         ret = None
         part_parameter = None
 
-        if type(name) == int:
+        if isinstance(name, int):
             # an integer was passed to the function -> assume it's the ID already
             ret = name
-        elif type(name) == str:
+        elif isinstance(name, str):
             part_parameter = PartParameterTemplate.objects.filter(name=name).first()
 
             if part_parameter:
@@ -80,7 +80,7 @@ class CategoryApi(rest_viewsets.ViewSet):
         return self.update(request, pk, partial=True)
     
     def update(self, request, pk=None, **kwargs):
-        from .models import SelectedCategory, PartParameterTemplate
+        from .models import SelectedCategory
 
         category = get_object_or_404(SelectedCategory, pk=pk)
 
@@ -109,7 +109,7 @@ class CategoryApi(rest_viewsets.ViewSet):
         # Add PartParameterTemplate keys
         # Allow passing the parameter name instead of the id
         for parameter in ['default_value_parameter_template', 'footprint_parameter_template']:
-            key = 'name' if type(request.data.get(parameter)) == str else 'pk'
+            key = 'name' if isinstance(request.data.get(parameter), str) else 'pk'
             validated_data[parameter] = PartParameterTemplate.objects.filter(**{key:request.data.get(parameter)}).first()
 
         serializer = serializers.KicadDetailedCategorySerializer()

--- a/inventree_kicad/viewsets.py
+++ b/inventree_kicad/viewsets.py
@@ -113,7 +113,9 @@ class CategoryApi(rest_viewsets.ViewSet):
             validated_data[parameter] = PartParameterTemplate.objects.filter(**{key:request.data.get(parameter)}).first()
 
         serializer = serializers.KicadDetailedCategorySerializer()
-        serializer.create(validated_data)
+        created_category = serializer.create(validated_data)
+
+        serializer = serializers.KicadDetailedCategorySerializer(created_category)
 
         return response.Response(serializer.data)
     


### PR DESCRIPTION
Added standard REST API Calls to manage the selected KiCad categories.
This makes it possible to create the categories without the need to go through the admin page and the tedious process, in case you want to add a lot.

It supports the `.list()`, `.retrieve()`, `.create()`, `.update()`, `.partial_update()`, and `.destroy()` functionality. 
The endpoints are reachable under 
`/plugin/kicad-library-plugin/api/category/` and `/plugin/kicad-library-plugin/api/category/<pk>/` respectively.

The serializer is showing the Inventree category and the parameter templates in detail, instead of just the id. 

For convenience, the default value parameter and footprint parameter can be created/updated also via name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a structured API endpoint for category management, allowing users to perform CRUD operations on categories.
	- Added a detailed serializer for KiCad categories that adapts serialization depth based on request methods.

- **Bug Fixes**
	- Enhanced error handling during category retrieval to ensure meaningful responses.

- **Chores**
	- Improved overall API structure for better accessibility and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->