### PR TITLE
Add setting to use IPN over Name

### DIFF
--- a/inventree_kicad/KiCadLibraryPlugin.py
+++ b/inventree_kicad/KiCadLibraryPlugin.py
@@ -127,6 +127,12 @@ class KiCadLibraryPlugin(UrlsMixin, AppMixin, SettingsMixin, SettingsContentMixi
             'validator': bool,
             'default': False,
         },
+        'KICAD_USE_IPN_AS_NAME': {
+            'name': _('Use IPN insead of Name'),
+            'description': _('When True, the plugin will provide IPN instead of Name'),
+            'validator': bool,
+            'default': False,
+        },
         'IMPORT_INVENTREE_ID_FALLBACK': {
             'name': _('[KiCad Metadata Import] Match Against Part Name'),
             'description': _(

--- a/inventree_kicad/KiCadLibraryPlugin.py
+++ b/inventree_kicad/KiCadLibraryPlugin.py
@@ -129,7 +129,7 @@ class KiCadLibraryPlugin(UrlsMixin, AppMixin, SettingsMixin, SettingsContentMixi
         },
         'KICAD_USE_IPN_AS_NAME': {
             'name': _('Use IPN insead of Name'),
-            'description': _('When True, the plugin will provide IPN instead of Name'),
+            'description': _('When True, the plugin will use IPN instead of Name'),
             'validator': bool,
             'default': False,
         },

--- a/inventree_kicad/serializers.py
+++ b/inventree_kicad/serializers.py
@@ -54,8 +54,17 @@ class KicadDetailedPartSerializer(serializers.ModelSerializer):
     exclude_from_bom = serializers.SerializerMethodField('get_exclude_from_bom')
     exclude_from_board = serializers.SerializerMethodField('get_exclude_from_board')
     exclude_from_sim = serializers.SerializerMethodField('get_exclude_from_sim')
+    name = serializers.SerializerMethodField('get_name')
 
     fields = serializers.SerializerMethodField('get_kicad_fields')
+
+    def get_name(self, part):
+        """Check against the plugins setting to see if the parts name, or IPN should be used.
+        """
+
+        use_ipn = self.plugin.get_setting('KICAD_USE_IPN_AS_NAME', False)
+
+        return part.IPN if use_ipn else part.name
 
     def get_kicad_category(self, part):
         """For the provided part instance, find the associated SelectedCategory instance.
@@ -428,6 +437,16 @@ class KicadPreviewPartSerializer(serializers.ModelSerializer):
 
     description = serializers.SerializerMethodField('get_description')
     stock = serializers.SerializerMethodField('get_stock')
+
+    name = serializers.SerializerMethodField('get_name')
+
+    def get_name(self, part):
+        """Check against the plugins setting to see if the parts name, or IPN should be used.
+        """
+
+        use_ipn = self.plugin.get_setting('KICAD_USE_IPN_AS_NAME', False)
+
+        return part.IPN if use_ipn else part.name
 
     def get_stock(self, part):
         """Custom name function.

--- a/inventree_kicad/serializers.py
+++ b/inventree_kicad/serializers.py
@@ -59,7 +59,7 @@ class KicadDetailedPartSerializer(serializers.ModelSerializer):
     fields = serializers.SerializerMethodField('get_kicad_fields')
 
     def get_name(self, part):
-        """Check against the plugins setting to see if the parts name, or IPN should be used.
+        """Check against the plugin's setting to see if the part's name, or IPN should be used.
         """
 
         use_ipn = self.plugin.get_setting('KICAD_USE_IPN_AS_NAME', False)
@@ -441,7 +441,7 @@ class KicadPreviewPartSerializer(serializers.ModelSerializer):
     name = serializers.SerializerMethodField('get_name')
 
     def get_name(self, part):
-        """Check against the plugins setting to see if the parts name, or IPN should be used.
+        """Check against the plugin's setting to see if the part's name, or IPN should be used.
         """
 
         use_ipn = self.plugin.get_setting('KICAD_USE_IPN_AS_NAME', False)


### PR DESCRIPTION
Our planned use of InvenTree Part IPN and Names would make using part names in KiCad messy.

This pull request adds a setting to instead provide the parts IPN over Name to KiCad.

This way a parts name can be changed, updated/fixed etc without breaking library links. As they'd be attached to the IPN instead.