### PR TITLE
[bug] Import error fix

### DIFF
--- a/inventree_kicad/KiCadLibraryPlugin.py
+++ b/inventree_kicad/KiCadLibraryPlugin.py
@@ -19,12 +19,23 @@ from InvenTree.helpers import str2bool
 from common.notifications import logger
 from part.models import Part, PartParameterTemplate, PartParameter
 from plugin import InvenTreePlugin
-from plugin.base.integration.mixins import SettingsContentMixin
 from plugin.mixins import UrlsMixin, AppMixin, SettingsMixin
 import xml.etree.ElementTree as elementTree
 
 from .models import ProgressIndicator
 from .version import KICAD_PLUGIN_VERSION
+
+
+try:
+    from plugin.base.integration.mixins import SettingsContentMixin
+except ImportError:
+    class SettingsContentMixin:
+        """Dummy mixin class for backwards compatibility.
+        
+        With the move the modern UI, this mixin is no longer used.
+        It is included here to maintain compatibility with older versions of InvenTree.
+        """
+        ...
 
 
 class KiCadLibraryPlugin(UrlsMixin, AppMixin, SettingsMixin, SettingsContentMixin, InvenTreePlugin):


### PR DESCRIPTION
Fixes a an issue which prevents the plugin from loading in modern InvenTree setup.

The upcoming 1.0.0 release removes the "SettingsContentMixin" class - refer to the [new plugin docs](https://docs.inventree.org/en/latest/plugins/)

As the plugin code currently stands, it will fail import due to a wrong path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved compatibility with older environments to prevent import errors. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->