### PR TITLE
Remove spurious white space

### DIFF
--- a/inventree_kicad/serializers.py
+++ b/inventree_kicad/serializers.py
@@ -270,7 +270,7 @@ class KicadDetailedPartSerializer(serializers.ModelSerializer):
             self.plugin.get_setting('KICAD_EXCLUDE_FROM_BOM_PARAMETER', None),
             self.plugin.get_setting('KICAD_EXCLUDE_FROM_BOARD_PARAMETER', None),
             self.plugin.get_setting('KICAD_EXCLUDE_FROM_SIM_PARAMETER', None),
-            self.plugin.get_setting('KICAD_VALUE_PARAMETER ', None),
+            self.plugin.get_setting('KICAD_VALUE_PARAMETER', None),
             self.plugin.get_setting('KICAD_FIELD_VISIBILITY_PARAMETER', None),
         ]
 


### PR DESCRIPTION
CodeRabbit caught this in #116 but I thought is was unrelated enough to put in its own PR. It looks like in the check for custom fields, `KICAD_VALUE_PARAMETER` got an extra trailing white space which means values would show up as a custom field. I'm not sure why this wasn't causing issues, but I believe this is no more correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected handling of the default value parameter in KiCad custom fields. When a category has a configured default value parameter, it is now properly excluded from the list of custom fields, preventing it from appearing alongside other parameters. This restores expected behavior and consistency with user settings, without affecting other custom field functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->