### PR TITLE
Add field to hide inactive parts in the KiCad PartsPreviewList

### DIFF
--- a/inventree_kicad/KiCadLibraryPlugin.py
+++ b/inventree_kicad/KiCadLibraryPlugin.py
@@ -174,6 +174,12 @@ class KiCadLibraryPlugin(UrlsMixin, AppMixin, SettingsMixin, SettingsContentMixi
             'validator': bool,
             'default': True,
         },
+        'KICAD_HIDE_INACTIVE_PARTS': {
+            'name': _('Hide Inactive Parts'),
+            'description': _('When activated, inactive parts will be hidden from the KiCad parts preview list'),
+            'validator': bool,
+            'default': True,
+        },
     }
 
     def get_settings_content(self, request):

--- a/inventree_kicad/viewsets.py
+++ b/inventree_kicad/viewsets.py
@@ -181,6 +181,9 @@ class PartsPreviewList(generics.ListAPIView):
             else:
                 queryset = queryset.filter(category=category)
 
+        if str2bool(plugin.get_setting('KICAD_HIDE_INACTIVE_PARTS', True)):
+            queryset = queryset.filter(active=True)
+
         queryset = serializers.KicadPreviewPartSerializer.annotate_queryset(queryset)
 
         return queryset


### PR DESCRIPTION
* Introduced 'KICAD_HIDE_INACTIVE_PARTS' setting.
* Filters out inactive parts from the KiCad parts preview list when activated.